### PR TITLE
Add web3-onboard support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@erc725/erc725.js": "^0.21.2",
         "@lukso/lsp-smart-contracts": "^0.12.1",
-        "@lukso/web3-onboard-config": "^1.0.3",
+        "@lukso/web3-onboard-config": "^1.1.0",
         "@web3-onboard/core": "^2.21.2",
         "@web3-onboard/injected-wallets": "^2.10.10",
         "ethereum-blockies-base64": "^1.0.2",
@@ -1946,9 +1946,9 @@
       }
     },
     "node_modules/@lukso/web3-onboard-config": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@lukso/web3-onboard-config/-/web3-onboard-config-1.0.3.tgz",
-      "integrity": "sha512-3SD6pYFTcZ2kuU6s7rgRQnwPzQ9kHbnLr5UJJxGMdKRuC/7gTYpdMEAaussoWdu8YHMsN2yKGdtWwqGomThD6A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukso/web3-onboard-config/-/web3-onboard-config-1.1.0.tgz",
+      "integrity": "sha512-WmjWXGPQuMEcw/OdWcS1mJ2pWiwLoaI+D/GN5AOxZ5m5Xm4/yqceMtZO3ojapgd8hdlSmsohKNHjg+M+CPT8dw==",
       "dependencies": {
         "@web3-onboard/common": "^2.3.3",
         "eip-712": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@erc725/erc725.js": "^0.21.2",
         "@lukso/lsp-smart-contracts": "^0.12.1",
+        "@lukso/web3-onboard-config": "^1.0.3",
+        "@web3-onboard/core": "^2.21.2",
+        "@web3-onboard/injected-wallets": "^2.10.10",
         "ethereum-blockies-base64": "^1.0.2",
         "ethers": "^6.8.1",
         "next": "14.0.2",
@@ -630,6 +633,336 @@
         "solidity-bytes-utils": "0.8.0"
       }
     },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.8.tgz",
+      "integrity": "sha512-31E2lxlGM1KEfivQl8Yf5aYU/mflz9g06H6S15ITUFQueMFtFjESRMoDSkvMo8thYvLBax+VKTPlpnx+sPicOA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.8.tgz",
+      "integrity": "sha512-B8JbS61bEunhfx8kasogFENgQfr/dIp+ggYXwTqdbMAgGDhRa3AaPpQMuQU0rNxDLECj6FhDzk1cF9WHMVwrtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.8.tgz",
+      "integrity": "sha512-rdqqYfRIn4jWOp+lzQttYMa2Xar3OK9Yt2fhOhzFXqg0rVWEfSclJvZq5fZslnz6ypHvVf3CT7qyf0A5pM682A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.8.tgz",
+      "integrity": "sha512-RQw9DemMbIq35Bprbboyf8SmOr4UXsRVxJ97LgB55VKKeJOOdvsIPy0nFyF2l8U+h4PtBx/1kRf0BelOYCiQcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.8.tgz",
+      "integrity": "sha512-3sur80OT9YdeZwIVgERAysAbwncom7b4bCI2XKLjMfPymTud7e/oY4y+ci1XVp5TfQp/bppn7xLw1n/oSQY3/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.8.tgz",
+      "integrity": "sha512-WAnPJSDattvS/XtPCTj1tPoTxERjcTpH6HsMr6ujTT+X6rylVe8ggxk8pVxzf5U1wh5sPODpawNicF5ta/9Tmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.8.tgz",
+      "integrity": "sha512-ICvZyOplIjmmhjd6mxi+zxSdpPTKFfyPPQMQTK/w+8eNK6WV01AjIztJALDtwNNfFhfZLux0tZLC+U9nSyA5Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.8.tgz",
+      "integrity": "sha512-H4vmI5PYqSvosPaTJuEppU9oz1dq2A7Mr2vyg5TF9Ga+3+MGgBdGzcyBP7qK9MrwFQZlvNyJrvz6GuCaj3OukQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.8.tgz",
+      "integrity": "sha512-z1zMZivxDLHWnyGOctT9JP70h0beY54xDDDJt4VpTX+iwA77IFsE1vCXWmprajJGa+ZYSqkSbRQ4eyLCpCmiCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.8.tgz",
+      "integrity": "sha512-1a8suQiFJmZz1khm/rDglOc8lavtzEMRo0v6WhPgxkrjcU0LkHj+TwBrALwoz/OtMExvsqbbMI0ChyelKabSvQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.8.tgz",
+      "integrity": "sha512-fHZWS2JJxnXt1uYJsDv9+b60WCc2RlvVAy1F76qOLtXRO+H4mjt3Tr6MJ5l7Q78X8KgCFudnTuiQRBhULUyBKQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.8.tgz",
+      "integrity": "sha512-Wy/z0EL5qZYLX66dVnEg9riiwls5IYnziwuju2oUiuxVc+/edvqXa04qNtbrs0Ukatg5HEzqT94Zs7J207dN5Q==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.8.tgz",
+      "integrity": "sha512-ETaW6245wK23YIEufhMQ3HSeHO7NgsLx8gygBVldRHKhOlD1oNeNy/P67mIh1zPn2Hr2HLieQrt6tWrVwuqrxg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.8.tgz",
+      "integrity": "sha512-T2DRQk55SgoleTP+DtPlMrxi/5r9AeFgkhkZ/B0ap99zmxtxdOixOMI570VjdRCs9pE4Wdkz7JYrsPvsl7eESg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.8.tgz",
+      "integrity": "sha512-NPxbdmmo3Bk7mbNeHmcCd7R7fptJaczPYBaELk6NcXxy7HLNyWwCyDJ/Xx+/YcNH7Im5dHdx9gZ5xIwyliQCbg==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.8.tgz",
+      "integrity": "sha512-lytMAVOM3b1gPypL2TRmZ5rnXl7+6IIk8uB3eLsV1JwcizuolblXRrc5ShPrO9ls/b+RTp+E6gbsuLWHWi2zGg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.8.tgz",
+      "integrity": "sha512-hvWVo2VsXz/8NVt1UhLzxwAfo5sioj92uo0bCfLibB0xlOmimU/DeAEsQILlBQvkhrGjamP0/el5HU76HAitGw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.8.tgz",
+      "integrity": "sha512-/7Y7u77rdvmGTxR83PgaSvSBJCC2L3Kb1M/+dmSIvRvQPXXCuC97QAwMugBNG0yGcbEGfFBH7ojPzAOxfGNkwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.8.tgz",
+      "integrity": "sha512-9Lc4s7Oi98GqFA4HzA/W2JHIYfnXbUYgekUP/Sm4BG9sfLjyv6GKKHKKVs83SMicBF2JwAX6A1PuOLMqpD001w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.8.tgz",
+      "integrity": "sha512-rq6WzBGjSzihI9deW3fC2Gqiak68+b7qo5/3kmB6Gvbh/NYPA0sJhrnp7wgV4bNwjqM+R2AApXGxMO7ZoGhIJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.8.tgz",
+      "integrity": "sha512-AIAbverbg5jMvJznYiGhrd3sumfwWs8572mIJL5NQjJa06P8KfCPWZQ0NwZbPQnbQi9OWSZhFVSUWjjIrn4hSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.8.tgz",
+      "integrity": "sha512-bfZ0cQ1uZs2PqpulNL5j/3w+GDhP36k1K5c38QdQg+Swy51jFZWWeIkteNsufkQxp986wnqRRsb/bHbY1WQ7TA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -873,6 +1206,25 @@
         "@ethersproject/bytes": "^5.7.0"
       }
     },
+    "node_modules/@ethersproject/basex": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.5.0.tgz",
+      "integrity": "sha512-ZIodwhHpVJ0Y3hUCfUucmxKsWQA5TMnavp5j/UOuDdzZWzJlRmuOjcTMIGgHCYuZmHt36BfiSyQPSRskPxbfaQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0"
+      }
+    },
     "node_modules/@ethersproject/bignumber": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
@@ -929,6 +1281,33 @@
         "@ethersproject/bignumber": "^5.7.0"
       }
     },
+    "node_modules/@ethersproject/contracts": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.5.0.tgz",
+      "integrity": "sha512-2viY7NzyvJkh+Ug17v7g3/IJC8HqZBDcOjYARZLdzRxrfGlRgmYgl6xPRKVbEzy1dWKw/iv7chDcS83pg6cLxg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "^5.5.0",
+        "@ethersproject/abstract-provider": "^5.5.0",
+        "@ethersproject/abstract-signer": "^5.5.0",
+        "@ethersproject/address": "^5.5.0",
+        "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/constants": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/transactions": "^5.5.0"
+      }
+    },
     "node_modules/@ethersproject/hash": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
@@ -954,6 +1333,70 @@
         "@ethersproject/properties": "^5.7.0",
         "@ethersproject/strings": "^5.7.0"
       }
+    },
+    "node_modules/@ethersproject/hdnode": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.5.0.tgz",
+      "integrity": "sha512-mcSOo9zeUg1L0CoJH7zmxwUG5ggQHU1UrRf8jyTYy6HxdZV+r0PBoL1bxr+JHIPXRzS6u/UW4mEn43y0tmyF8Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.5.0",
+        "@ethersproject/basex": "^5.5.0",
+        "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/pbkdf2": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/sha2": "^5.5.0",
+        "@ethersproject/signing-key": "^5.5.0",
+        "@ethersproject/strings": "^5.5.0",
+        "@ethersproject/transactions": "^5.5.0",
+        "@ethersproject/wordlists": "^5.5.0"
+      }
+    },
+    "node_modules/@ethersproject/json-wallets": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.5.0.tgz",
+      "integrity": "sha512-9lA21XQnCdcS72xlBn1jfQdj2A1VUxZzOzi9UkNdnokNKke/9Ya2xA9aIK1SC3PQyBDLt4C+dfps7ULpkvKikQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.5.0",
+        "@ethersproject/address": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/hdnode": "^5.5.0",
+        "@ethersproject/keccak256": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/pbkdf2": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/random": "^5.5.0",
+        "@ethersproject/strings": "^5.5.0",
+        "@ethersproject/transactions": "^5.5.0",
+        "aes-js": "3.0.0",
+        "scrypt-js": "3.0.1"
+      }
+    },
+    "node_modules/@ethersproject/json-wallets/node_modules/aes-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
     },
     "node_modules/@ethersproject/keccak256": {
       "version": "5.7.0",
@@ -1007,6 +1450,25 @@
         "@ethersproject/logger": "^5.7.0"
       }
     },
+    "node_modules/@ethersproject/pbkdf2": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.5.0.tgz",
+      "integrity": "sha512-SaDvQFvXPnz1QGpzr6/HToLifftSXGoXrbpZ6BvoZhmx4bNLHrxDe8MZisuecyOziP1aVEwzC2Hasj+86TgWVg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/sha2": "^5.5.0"
+      }
+    },
     "node_modules/@ethersproject/properties": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
@@ -1023,6 +1485,81 @@
       ],
       "dependencies": {
         "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/providers": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.5.3.tgz",
+      "integrity": "sha512-ZHXxXXXWHuwCQKrgdpIkbzMNJMvs+9YWemanwp1fA7XZEv7QlilseysPvQe0D7Q7DlkJX/w/bGA1MdgK2TbGvA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.5.0",
+        "@ethersproject/abstract-signer": "^5.5.0",
+        "@ethersproject/address": "^5.5.0",
+        "@ethersproject/basex": "^5.5.0",
+        "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/constants": "^5.5.0",
+        "@ethersproject/hash": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/networks": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/random": "^5.5.0",
+        "@ethersproject/rlp": "^5.5.0",
+        "@ethersproject/sha2": "^5.5.0",
+        "@ethersproject/strings": "^5.5.0",
+        "@ethersproject/transactions": "^5.5.0",
+        "@ethersproject/web": "^5.5.0",
+        "bech32": "1.1.4",
+        "ws": "7.4.6"
+      }
+    },
+    "node_modules/@ethersproject/providers/node_modules/ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ethersproject/random": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.5.1.tgz",
+      "integrity": "sha512-YaU2dQ7DuhL5Au7KbcQLHxcRHfgyNgvFV4sQOo0HrtW3Zkrc9ctWNz8wXQ4uCSfSDsqX2vcjhroxU5RQRV0nqA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0"
       }
     },
     "node_modules/@ethersproject/rlp": {
@@ -1042,6 +1579,26 @@
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/sha2": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.5.0.tgz",
+      "integrity": "sha512-B5UBoglbCiHamRVPLA110J+2uqsifpZaTmid2/7W5rbtYVz6gus6/hSDieIU/6gaKIDcOj12WnOdiymEUHIAOA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "hash.js": "1.1.7"
       }
     },
     "node_modules/@ethersproject/signing-key": {
@@ -1065,6 +1622,29 @@
         "bn.js": "^5.2.1",
         "elliptic": "6.5.4",
         "hash.js": "1.1.7"
+      }
+    },
+    "node_modules/@ethersproject/solidity": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.5.0.tgz",
+      "integrity": "sha512-9NgZs9LhGMj6aCtHXhtmFQ4AN4sth5HuFXVvAQtzmm0jpSCNOTGtrHZJAeYTh7MBjRR8brylWZxBZR9zDStXbw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/keccak256": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/sha2": "^5.5.0",
+        "@ethersproject/strings": "^5.5.0"
       }
     },
     "node_modules/@ethersproject/strings": {
@@ -1113,6 +1693,58 @@
         "@ethersproject/signing-key": "^5.7.0"
       }
     },
+    "node_modules/@ethersproject/units": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.5.0.tgz",
+      "integrity": "sha512-7+DpjiZk4v6wrikj+TCyWWa9dXLNU73tSTa7n0TSJDxkYbV3Yf1eRh9ToMLlZtuctNYu9RDNNy2USq3AdqSbag==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/constants": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0"
+      }
+    },
+    "node_modules/@ethersproject/wallet": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.5.0.tgz",
+      "integrity": "sha512-Mlu13hIctSYaZmUOo7r2PhNSd8eaMPVXe1wxrz4w4FCE4tDYBywDH+bAR1Xz2ADyXGwqYMwstzTrtUVIsKDO0Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.5.0",
+        "@ethersproject/abstract-signer": "^5.5.0",
+        "@ethersproject/address": "^5.5.0",
+        "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/hash": "^5.5.0",
+        "@ethersproject/hdnode": "^5.5.0",
+        "@ethersproject/json-wallets": "^5.5.0",
+        "@ethersproject/keccak256": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/random": "^5.5.0",
+        "@ethersproject/signing-key": "^5.5.0",
+        "@ethersproject/transactions": "^5.5.0",
+        "@ethersproject/wordlists": "^5.5.0"
+      }
+    },
     "node_modules/@ethersproject/web": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
@@ -1133,6 +1765,96 @@
         "@ethersproject/logger": "^5.7.0",
         "@ethersproject/properties": "^5.7.0",
         "@ethersproject/strings": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/wordlists": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.5.0.tgz",
+      "integrity": "sha512-bL0UTReWDiaQJJYOC9sh/XcRu/9i2jMrzf8VLRmPKx58ckSlOJiohODkECCO50dtLZHcGU6MLXQ4OOrgBwP77Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/hash": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/strings": "^5.5.0"
+      }
+    },
+    "node_modules/@findeth/abi": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@findeth/abi/-/abi-0.3.1.tgz",
+      "integrity": "sha512-T9HUVEjEgM0MzVLY4gs52ffz5AlHeC3CSGFcEzL4ojKMVzMxa3na1GW/XCmunrhnWP2cDh4fE2MhqLxA0CHqTw==",
+      "dependencies": {
+        "keccak": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.4.tgz",
+      "integrity": "sha512-EBikYFp2JCdIfGEb5G9dyCkTGDmC57KSHhRQOC3aYxoPWVZvfWCDjZwkGYHN7Lis/fmuWl906bnNTJifDQ3sXw==",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "0.2.25",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.1.tgz",
+      "integrity": "sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.0.tgz",
+      "integrity": "sha512-Qxv/lmCN6hKpBSss2uQ8IROVnta2r9jd3ymUEIjm2UyIkUCHVcbUVRGL/KS/wv7876edvsPe+hjHVJ4z8YuVaw==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.4",
+        "@formatjs/icu-skeleton-parser": "1.3.6",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.6.tgz",
+      "integrity": "sha512-I96mOxvml/YLrwU2Txnd4klA7V8fRhb6JG/4hm3VMNmeJo1F03IpV2L3wWt7EweqNLES59SZ4d6hVOPCSf80Bg==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.25.tgz",
+      "integrity": "sha512-YmLcX70BxoSopLFdLr1Ds99NdlTI2oWoLbaUW2M406lxOIPzE1KQhRz2fPUkq34xVZQaihCoU29h0KK7An3bhA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1222,6 +1944,21 @@
         "@openzeppelin/contracts-upgradeable": "^4.9.2",
         "solidity-bytes-utils": "0.8.0"
       }
+    },
+    "node_modules/@lukso/web3-onboard-config": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lukso/web3-onboard-config/-/web3-onboard-config-1.0.3.tgz",
+      "integrity": "sha512-3SD6pYFTcZ2kuU6s7rgRQnwPzQ9kHbnLr5UJJxGMdKRuC/7gTYpdMEAaussoWdu8YHMsN2yKGdtWwqGomThD6A==",
+      "dependencies": {
+        "@web3-onboard/common": "^2.3.3",
+        "eip-712": "^1.0.0",
+        "eventemitter3": "^5.0.1"
+      }
+    },
+    "node_modules/@lukso/web3-onboard-config/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/@metamask/eth-sig-util": {
       "version": "4.0.1",
@@ -1557,6 +2294,24 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -1982,6 +2737,990 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@web3-onboard/common": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@web3-onboard/common/-/common-2.3.3.tgz",
+      "integrity": "sha512-Ytppszqe77VY8WglRdr/Lfx+HmcZ2hXQEkBA23JaVYmzKvP/mC6j+sjGUD8CgXDpRRxyKoiRj6nz95GRABie6Q==",
+      "dependencies": {
+        "bignumber.js": "^9.1.0",
+        "ethers": "5.5.4",
+        "joi": "17.9.1"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/@ethersproject/abi": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.5.0.tgz",
+      "integrity": "sha512-loW7I4AohP5KycATvc0MgujU6JyCHPqHdeoo9z3Nr9xEiNioxa65ccdm1+fsoJhkuhdRtfcL8cfyGamz2AxZ5w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/address": "^5.5.0",
+        "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/constants": "^5.5.0",
+        "@ethersproject/hash": "^5.5.0",
+        "@ethersproject/keccak256": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/strings": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/@ethersproject/abstract-provider": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.5.1.tgz",
+      "integrity": "sha512-m+MA/ful6eKbxpr99xUYeRvLkfnlqzrF8SZ46d/xFB1A7ZVknYc/sXJG0RcufF52Qn2jeFj1hhcoQ7IXjNKUqg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/networks": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/transactions": "^5.5.0",
+        "@ethersproject/web": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/@ethersproject/abstract-signer": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz",
+      "integrity": "sha512-lj//7r250MXVLKI7sVarXAbZXbv9P50lgmJQGr2/is82EwEb8r7HrxsmMqAjTsztMYy7ohrIhGMIml+Gx4D3mA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.5.0",
+        "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/@ethersproject/address": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.5.0.tgz",
+      "integrity": "sha512-l4Nj0eWlTUh6ro5IbPTgbpT4wRbdH5l8CQf7icF7sb/SI3Nhd9Y9HzhonTSTi6CefI0necIw7LJqQPopPLZyWw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/keccak256": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/rlp": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/@ethersproject/base64": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.5.0.tgz",
+      "integrity": "sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/@ethersproject/bignumber": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.5.0.tgz",
+      "integrity": "sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "bn.js": "^4.11.9"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/@ethersproject/bytes": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.5.0.tgz",
+      "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/logger": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/@ethersproject/constants": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.5.0.tgz",
+      "integrity": "sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/@ethersproject/hash": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.5.0.tgz",
+      "integrity": "sha512-dnGVpK1WtBjmnp3mUT0PlU2MpapnwWI0PibldQEq1408tQBAbZpPidkWoVVuNMOl/lISO3+4hXZWCL3YV7qzfg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.5.0",
+        "@ethersproject/address": "^5.5.0",
+        "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/keccak256": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/strings": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/@ethersproject/keccak256": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.5.0.tgz",
+      "integrity": "sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.5.0",
+        "js-sha3": "0.8.0"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/@ethersproject/logger": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.5.0.tgz",
+      "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ]
+    },
+    "node_modules/@web3-onboard/common/node_modules/@ethersproject/networks": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.5.2.tgz",
+      "integrity": "sha512-NEqPxbGBfy6O3x4ZTISb90SjEDkWYDUbEeIFhJly0F7sZjoQMnj5KYzMSkMkLKZ+1fGpx00EDpHQCy6PrDupkQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/logger": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/@ethersproject/properties": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.5.0.tgz",
+      "integrity": "sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/logger": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/@ethersproject/rlp": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.5.0.tgz",
+      "integrity": "sha512-hLv8XaQ8PTI9g2RHoQGf/WSxBfTB/NudRacbzdxmst5VHAqd1sMibWG7SENzT5Dj3yZ3kJYx+WiRYEcQTAkcYA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/@ethersproject/signing-key": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.5.0.tgz",
+      "integrity": "sha512-5VmseH7qjtNmDdZBswavhotYbWB0bOwKIlOTSlX14rKn5c11QmJwGt4GHeo7NrL/Ycl7uo9AHvEqs5xZgFBTng==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "bn.js": "^4.11.9",
+        "elliptic": "6.5.4",
+        "hash.js": "1.1.7"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/@ethersproject/strings": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.5.0.tgz",
+      "integrity": "sha512-9fy3TtF5LrX/wTrBaT8FGE6TDJyVjOvXynXJz5MT5azq+E6D92zuKNx7i29sWW2FjVOaWjAsiZ1ZWznuduTIIQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/constants": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/@ethersproject/transactions": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.5.0.tgz",
+      "integrity": "sha512-9RZYSKX26KfzEd/1eqvv8pLauCKzDTub0Ko4LfIgaERvRuwyaNV78mJs7cpIgZaDl6RJui4o49lHwwCM0526zA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/address": "^5.5.0",
+        "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/constants": "^5.5.0",
+        "@ethersproject/keccak256": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/rlp": "^5.5.0",
+        "@ethersproject/signing-key": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/@ethersproject/web": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.5.1.tgz",
+      "integrity": "sha512-olvLvc1CB12sREc1ROPSHTdFCdvMh0J5GSJYiQg2D0hdD4QmJDy8QYDb1CvoqD/bF1c++aeKv2sR5uduuG9dQg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/base64": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/strings": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
+    "node_modules/@web3-onboard/common/node_modules/ethers": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.5.4.tgz",
+      "integrity": "sha512-N9IAXsF8iKhgHIC6pquzRgPBJEzc9auw3JoRkaKe+y4Wl/LFBtDDunNe7YmdomontECAcC5APaAgWZBiu1kirw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "5.5.0",
+        "@ethersproject/abstract-provider": "5.5.1",
+        "@ethersproject/abstract-signer": "5.5.0",
+        "@ethersproject/address": "5.5.0",
+        "@ethersproject/base64": "5.5.0",
+        "@ethersproject/basex": "5.5.0",
+        "@ethersproject/bignumber": "5.5.0",
+        "@ethersproject/bytes": "5.5.0",
+        "@ethersproject/constants": "5.5.0",
+        "@ethersproject/contracts": "5.5.0",
+        "@ethersproject/hash": "5.5.0",
+        "@ethersproject/hdnode": "5.5.0",
+        "@ethersproject/json-wallets": "5.5.0",
+        "@ethersproject/keccak256": "5.5.0",
+        "@ethersproject/logger": "5.5.0",
+        "@ethersproject/networks": "5.5.2",
+        "@ethersproject/pbkdf2": "5.5.0",
+        "@ethersproject/properties": "5.5.0",
+        "@ethersproject/providers": "5.5.3",
+        "@ethersproject/random": "5.5.1",
+        "@ethersproject/rlp": "5.5.0",
+        "@ethersproject/sha2": "5.5.0",
+        "@ethersproject/signing-key": "5.5.0",
+        "@ethersproject/solidity": "5.5.0",
+        "@ethersproject/strings": "5.5.0",
+        "@ethersproject/transactions": "5.5.0",
+        "@ethersproject/units": "5.5.0",
+        "@ethersproject/wallet": "5.5.0",
+        "@ethersproject/web": "5.5.1",
+        "@ethersproject/wordlists": "5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/core": {
+      "version": "2.21.2",
+      "resolved": "https://registry.npmjs.org/@web3-onboard/core/-/core-2.21.2.tgz",
+      "integrity": "sha512-apzVi2zWqs4ktZBBJ60x1e4odI1mSoZ2c69bXUg36A0xI0iRFQ9Od44peI3mfTDEru7hWsr81Nv6l+v3HRSKLw==",
+      "dependencies": {
+        "@web3-onboard/common": "^2.3.3",
+        "bignumber.js": "^9.0.0",
+        "bnc-sdk": "^4.6.7",
+        "bowser": "^2.11.0",
+        "ethers": "5.5.3",
+        "eventemitter3": "^4.0.7",
+        "joi": "17.9.1",
+        "lodash.merge": "^4.6.2",
+        "lodash.partition": "^4.6.0",
+        "nanoid": "^4.0.0",
+        "rxjs": "^7.5.5",
+        "svelte": "^3.49.0",
+        "svelte-i18n": "^3.3.13"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/@ethersproject/abi": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.5.0.tgz",
+      "integrity": "sha512-loW7I4AohP5KycATvc0MgujU6JyCHPqHdeoo9z3Nr9xEiNioxa65ccdm1+fsoJhkuhdRtfcL8cfyGamz2AxZ5w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/address": "^5.5.0",
+        "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/constants": "^5.5.0",
+        "@ethersproject/hash": "^5.5.0",
+        "@ethersproject/keccak256": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/strings": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/@ethersproject/abstract-provider": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.5.1.tgz",
+      "integrity": "sha512-m+MA/ful6eKbxpr99xUYeRvLkfnlqzrF8SZ46d/xFB1A7ZVknYc/sXJG0RcufF52Qn2jeFj1hhcoQ7IXjNKUqg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/networks": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/transactions": "^5.5.0",
+        "@ethersproject/web": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/@ethersproject/abstract-signer": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz",
+      "integrity": "sha512-lj//7r250MXVLKI7sVarXAbZXbv9P50lgmJQGr2/is82EwEb8r7HrxsmMqAjTsztMYy7ohrIhGMIml+Gx4D3mA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.5.0",
+        "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/@ethersproject/address": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.5.0.tgz",
+      "integrity": "sha512-l4Nj0eWlTUh6ro5IbPTgbpT4wRbdH5l8CQf7icF7sb/SI3Nhd9Y9HzhonTSTi6CefI0necIw7LJqQPopPLZyWw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/keccak256": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/rlp": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/@ethersproject/base64": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.5.0.tgz",
+      "integrity": "sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/@ethersproject/bignumber": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.5.0.tgz",
+      "integrity": "sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "bn.js": "^4.11.9"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/@ethersproject/bytes": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.5.0.tgz",
+      "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/logger": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/@ethersproject/constants": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.5.0.tgz",
+      "integrity": "sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/@ethersproject/hash": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.5.0.tgz",
+      "integrity": "sha512-dnGVpK1WtBjmnp3mUT0PlU2MpapnwWI0PibldQEq1408tQBAbZpPidkWoVVuNMOl/lISO3+4hXZWCL3YV7qzfg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.5.0",
+        "@ethersproject/address": "^5.5.0",
+        "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/keccak256": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/strings": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/@ethersproject/keccak256": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.5.0.tgz",
+      "integrity": "sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.5.0",
+        "js-sha3": "0.8.0"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/@ethersproject/logger": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.5.0.tgz",
+      "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ]
+    },
+    "node_modules/@web3-onboard/core/node_modules/@ethersproject/networks": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.5.2.tgz",
+      "integrity": "sha512-NEqPxbGBfy6O3x4ZTISb90SjEDkWYDUbEeIFhJly0F7sZjoQMnj5KYzMSkMkLKZ+1fGpx00EDpHQCy6PrDupkQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/logger": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/@ethersproject/properties": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.5.0.tgz",
+      "integrity": "sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/logger": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/@ethersproject/providers": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.5.2.tgz",
+      "integrity": "sha512-hkbx7x/MKcRjyrO4StKXCzCpWer6s97xnm34xkfPiarhtEUVAN4TBBpamM+z66WcTt7H5B53YwbRj1n7i8pZoQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.5.0",
+        "@ethersproject/abstract-signer": "^5.5.0",
+        "@ethersproject/address": "^5.5.0",
+        "@ethersproject/basex": "^5.5.0",
+        "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/constants": "^5.5.0",
+        "@ethersproject/hash": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/networks": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/random": "^5.5.0",
+        "@ethersproject/rlp": "^5.5.0",
+        "@ethersproject/sha2": "^5.5.0",
+        "@ethersproject/strings": "^5.5.0",
+        "@ethersproject/transactions": "^5.5.0",
+        "@ethersproject/web": "^5.5.0",
+        "bech32": "1.1.4",
+        "ws": "7.4.6"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/@ethersproject/rlp": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.5.0.tgz",
+      "integrity": "sha512-hLv8XaQ8PTI9g2RHoQGf/WSxBfTB/NudRacbzdxmst5VHAqd1sMibWG7SENzT5Dj3yZ3kJYx+WiRYEcQTAkcYA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/@ethersproject/signing-key": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.5.0.tgz",
+      "integrity": "sha512-5VmseH7qjtNmDdZBswavhotYbWB0bOwKIlOTSlX14rKn5c11QmJwGt4GHeo7NrL/Ycl7uo9AHvEqs5xZgFBTng==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "bn.js": "^4.11.9",
+        "elliptic": "6.5.4",
+        "hash.js": "1.1.7"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/@ethersproject/strings": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.5.0.tgz",
+      "integrity": "sha512-9fy3TtF5LrX/wTrBaT8FGE6TDJyVjOvXynXJz5MT5azq+E6D92zuKNx7i29sWW2FjVOaWjAsiZ1ZWznuduTIIQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/constants": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/@ethersproject/transactions": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.5.0.tgz",
+      "integrity": "sha512-9RZYSKX26KfzEd/1eqvv8pLauCKzDTub0Ko4LfIgaERvRuwyaNV78mJs7cpIgZaDl6RJui4o49lHwwCM0526zA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/address": "^5.5.0",
+        "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/constants": "^5.5.0",
+        "@ethersproject/keccak256": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/rlp": "^5.5.0",
+        "@ethersproject/signing-key": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/@ethersproject/web": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.5.1.tgz",
+      "integrity": "sha512-olvLvc1CB12sREc1ROPSHTdFCdvMh0J5GSJYiQg2D0hdD4QmJDy8QYDb1CvoqD/bF1c++aeKv2sR5uduuG9dQg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/base64": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/strings": "^5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
+    "node_modules/@web3-onboard/core/node_modules/ethers": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.5.3.tgz",
+      "integrity": "sha512-fTT4WT8/hTe/BLwRUtl7I5zlpF3XC3P/Xwqxc5AIP2HGlH15qpmjs0Ou78az93b1rLITzXLFxoNX63B8ZbUd7g==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "5.5.0",
+        "@ethersproject/abstract-provider": "5.5.1",
+        "@ethersproject/abstract-signer": "5.5.0",
+        "@ethersproject/address": "5.5.0",
+        "@ethersproject/base64": "5.5.0",
+        "@ethersproject/basex": "5.5.0",
+        "@ethersproject/bignumber": "5.5.0",
+        "@ethersproject/bytes": "5.5.0",
+        "@ethersproject/constants": "5.5.0",
+        "@ethersproject/contracts": "5.5.0",
+        "@ethersproject/hash": "5.5.0",
+        "@ethersproject/hdnode": "5.5.0",
+        "@ethersproject/json-wallets": "5.5.0",
+        "@ethersproject/keccak256": "5.5.0",
+        "@ethersproject/logger": "5.5.0",
+        "@ethersproject/networks": "5.5.2",
+        "@ethersproject/pbkdf2": "5.5.0",
+        "@ethersproject/properties": "5.5.0",
+        "@ethersproject/providers": "5.5.2",
+        "@ethersproject/random": "5.5.1",
+        "@ethersproject/rlp": "5.5.0",
+        "@ethersproject/sha2": "5.5.0",
+        "@ethersproject/signing-key": "5.5.0",
+        "@ethersproject/solidity": "5.5.0",
+        "@ethersproject/strings": "5.5.0",
+        "@ethersproject/transactions": "5.5.0",
+        "@ethersproject/units": "5.5.0",
+        "@ethersproject/wallet": "5.5.0",
+        "@ethersproject/web": "5.5.1",
+        "@ethersproject/wordlists": "5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "node_modules/@web3-onboard/core/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@web3-onboard/injected-wallets": {
+      "version": "2.10.10",
+      "resolved": "https://registry.npmjs.org/@web3-onboard/injected-wallets/-/injected-wallets-2.10.10.tgz",
+      "integrity": "sha512-n05N6oDsUaZwFVKd76LU8IgzWdqqI2yc9zGxexb8d7QiCcbYZt5YWAcgesKLf/YaZn5/aIodn9BToMRqsdwabg==",
+      "dependencies": {
+        "@web3-onboard/common": "^2.3.3",
+        "joi": "17.9.1",
+        "lodash.uniqby": "^4.7.0"
+      }
     },
     "node_modules/abortcontroller-polyfill": {
       "version": "1.7.5",
@@ -2498,6 +4237,11 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
+    "node_modules/bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+    },
     "node_modules/bignumber.js": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
@@ -2529,6 +4273,33 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+    },
+    "node_modules/bnc-sdk": {
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/bnc-sdk/-/bnc-sdk-4.6.7.tgz",
+      "integrity": "sha512-jIQ6cmeRBgvH/YDLuYRr2+kxDGcAAi0SOvjlO5nQ5cWdbslw+ASWftd1HmxiVLNCiwEH5bSc/t8a0agZ5njTUQ==",
+      "dependencies": {
+        "crypto-es": "^1.2.2",
+        "nanoid": "^3.3.1",
+        "rxjs": "^6.6.3",
+        "sturdy-websocket": "^0.1.12"
+      }
+    },
+    "node_modules/bnc-sdk/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/bnc-sdk/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/body-parser": {
       "version": "1.20.2",
@@ -2565,6 +4336,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2941,6 +4717,21 @@
       "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
       "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
     },
+    "node_modules/cli-color": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.3.tgz",
+      "integrity": "sha512-OkoZnxyC4ERN3zLzZaY9Emb7f/MhBOIpePv0Ycok0fJYT+Ouo00UBEIwsVsr0yoow++n5YWlSUgST9GKhNHiRQ==",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.61",
+        "es6-iterator": "^2.0.3",
+        "memoizee": "^0.4.15",
+        "timers-ext": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -3144,6 +4935,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypto-es": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/crypto-es/-/crypto-es-1.2.7.tgz",
+      "integrity": "sha512-UUqiVJ2gUuZFmbFsKmud3uuLcNP2+Opt+5ysmljycFCyhA0+T16XJmo1ev/t5kMChMqWh7IEvURNCqsg+SjZGQ=="
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3242,6 +5038,14 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
@@ -3377,6 +5181,19 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "node_modules/eip-712": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eip-712/-/eip-712-1.0.0.tgz",
+      "integrity": "sha512-zVWGCUJQErhTpBH0mfYurP+t7wNdRizBq7PMAFj8M1Hq4/4QvKE7+FfXVcs7kL6b2ypbCnMgsimJQR1B2AfHpg==",
+      "dependencies": {
+        "@findeth/abi": "^0.3.0",
+        "@noble/hashes": "^1.0.0",
+        "superstruct": "^0.15.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.585",
@@ -3599,6 +5416,53 @@
       "dependencies": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
+      }
+    },
+    "node_modules/es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.8.tgz",
+      "integrity": "sha512-l7iffQpT2OrZfH2rXIp7/FkmaeZM0vxbxN9KfiCwGYuZqzMg/JdvX26R31Zxn/Pxvsrg3Y9N6XTcnknqDyyv4w==",
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.19.8",
+        "@esbuild/android-arm64": "0.19.8",
+        "@esbuild/android-x64": "0.19.8",
+        "@esbuild/darwin-arm64": "0.19.8",
+        "@esbuild/darwin-x64": "0.19.8",
+        "@esbuild/freebsd-arm64": "0.19.8",
+        "@esbuild/freebsd-x64": "0.19.8",
+        "@esbuild/linux-arm": "0.19.8",
+        "@esbuild/linux-arm64": "0.19.8",
+        "@esbuild/linux-ia32": "0.19.8",
+        "@esbuild/linux-loong64": "0.19.8",
+        "@esbuild/linux-mips64el": "0.19.8",
+        "@esbuild/linux-ppc64": "0.19.8",
+        "@esbuild/linux-riscv64": "0.19.8",
+        "@esbuild/linux-s390x": "0.19.8",
+        "@esbuild/linux-x64": "0.19.8",
+        "@esbuild/netbsd-x64": "0.19.8",
+        "@esbuild/openbsd-x64": "0.19.8",
+        "@esbuild/sunos-x64": "0.19.8",
+        "@esbuild/win32-arm64": "0.19.8",
+        "@esbuild/win32-ia32": "0.19.8",
+        "@esbuild/win32-x64": "0.19.8"
       }
     },
     "node_modules/escalade": {
@@ -4026,6 +5890,11 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -4606,6 +6475,15 @@
       "engines": {
         "node": ">=6.5.0",
         "npm": ">=3"
+      }
+    },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "node_modules/eventemitter3": {
@@ -5190,6 +7068,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="
+    },
     "node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -5209,6 +7092,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
     },
     "node_modules/gopd": {
       "version": "1.0.1",
@@ -5555,6 +7443,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/intl-messageformat": {
+      "version": "9.13.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.13.0.tgz",
+      "integrity": "sha512-7sGC7QnSQGa5LZP7bXLDhVDtQOeKGeBFGHF2Y8LVBwYZoQZCgWeKoPGTa5GMG8g/TzDgeXuYJQis7Ggiw2xTOw==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.4",
+        "@formatjs/fast-memoize": "1.2.1",
+        "@formatjs/icu-messageformat-parser": "2.1.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -5807,6 +7706,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
+    },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -5963,6 +7867,18 @@
       "dev": true,
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/joi": {
+      "version": "17.9.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.1.tgz",
+      "integrity": "sha512-FariIi9j6QODKATGBrEX7HZcja8Bsh3rfdGYy/Sb65sGlZWK/QWesU1ghk7aJWDj95knjXlQfSmzFSPPkLVsfw==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "node_modules/js-sha3": {
@@ -6335,11 +8251,25 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "node_modules/lodash.partition": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.partition/-/lodash.partition-4.6.0.tgz",
+      "integrity": "sha512-35L3dSF3Q6V1w5j6V3NhNlQjzsRDC/pYKCTdYTmwqSib+Q8ponkAmt/PwEOq3EmI38DSCl+SkIVwLd+uSlVdrg=="
+    },
+    "node_modules/lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww=="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -6373,6 +8303,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+      "dependencies": {
+        "es5-ext": "~0.10.2"
       }
     },
     "node_modules/ltgt": {
@@ -6423,6 +8361,21 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/memoizee": {
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
+      "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.53",
+        "es6-weak-map": "^2.0.3",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.2.2",
+        "lru-queue": "^0.1.0",
+        "next-tick": "^1.1.0",
+        "timers-ext": "^0.1.7"
+      }
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
@@ -6663,6 +8616,14 @@
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.14.0.tgz",
       "integrity": "sha512-qYvlv/exQ4+svI3UOvPUpLDF0OMX5euvUH0Ny4N5QyRyhNdgAgUrVH3iUINSzEPLvx0kbo/Bp28GJKIqvE7URw=="
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -7835,6 +9796,25 @@
       "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
       "integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA=="
     },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
@@ -8348,6 +10328,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/sturdy-websocket": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/sturdy-websocket/-/sturdy-websocket-0.1.12.tgz",
+      "integrity": "sha512-PA7h8LdjaMoIlC5HAwLVzae4raGWgyroscV4oUpEiTtEFINcNa47/CKYT3e98o+FfsJgrclI2pYpaJrz0aaoew==",
+      "dependencies": {
+        "lodash.defaults": "^4.2.0"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
@@ -8412,6 +10400,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/superstruct": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.15.5.tgz",
+      "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ=="
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -8433,6 +10426,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "3.59.2",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.59.2.tgz",
+      "integrity": "sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/svelte-i18n": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/svelte-i18n/-/svelte-i18n-3.7.4.tgz",
+      "integrity": "sha512-yGRCNo+eBT4cPuU7IVsYTYjxB7I2V8qgUZPlHnNctJj5IgbJgV78flsRzpjZ/8iUYZrS49oCt7uxlU3AZv/N5Q==",
+      "dependencies": {
+        "cli-color": "^2.0.3",
+        "deepmerge": "^4.2.2",
+        "esbuild": "^0.19.2",
+        "estree-walker": "^2",
+        "intl-messageformat": "^9.13.0",
+        "sade": "^1.8.1",
+        "tiny-glob": "^0.2.9"
+      },
+      "bin": {
+        "svelte-i18n": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "svelte": "^3 || ^4"
       }
     },
     "node_modules/swarm-js": {
@@ -8636,6 +10660,24 @@
       "integrity": "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/timers-ext": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "dependencies": {
+        "es5-ext": "~0.10.46",
+        "next-tick": "1"
+      }
+    },
+    "node_modules/tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dependencies": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
       }
     },
     "node_modules/to-fast-properties": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "dependencies": {
     "@erc725/erc725.js": "^0.21.2",
     "@lukso/lsp-smart-contracts": "^0.12.1",
+    "@lukso/web3-onboard-config": "^1.0.3",
+    "@web3-onboard/core": "^2.21.2",
+    "@web3-onboard/injected-wallets": "^2.10.10",
     "ethereum-blockies-base64": "^1.0.2",
     "ethers": "^6.8.1",
     "next": "14.0.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@erc725/erc725.js": "^0.21.2",
     "@lukso/lsp-smart-contracts": "^0.12.1",
-    "@lukso/web3-onboard-config": "^1.0.3",
+    "@lukso/web3-onboard-config": "^1.1.0",
     "@web3-onboard/core": "^2.21.2",
     "@web3-onboard/injected-wallets": "^2.10.10",
     "ethereum-blockies-base64": "^1.0.2",

--- a/public/lukso_wordmark_black.svg
+++ b/public/lukso_wordmark_black.svg
@@ -1,5 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 27.5.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 701 240.6" style="enable-background:new 0 0 701 240.6;" xml:space="preserve">
 <g>

--- a/public/lukso_wordmark_white.svg
+++ b/public/lukso_wordmark_white.svg
@@ -1,5 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 27.5.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 701 240.6" style="enable-background:new 0 0 701 240.6;" xml:space="preserve">
 <style type="text/css">

--- a/public/lyx_token_symbol.svg
+++ b/public/lyx_token_symbol.svg
@@ -1,5 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 27.5.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 550 604" style="enable-background:new 0 0 550 604;" xml:space="preserve">
 <style type="text/css">

--- a/src/app/config.ts
+++ b/src/app/config.ts
@@ -6,4 +6,8 @@ export const config = {
     title: 'LYX Builder',
     description: 'Open Source LUKSO Dev Stack',
   },
+  extension: {
+    name: 'Universal Profiles',
+    url: 'https://chrome.google.com/webstore/detail/universal-profiles/abpickdkkbnbcoepogfhkhennhfhehfn?hl=en',
+  },
 }

--- a/src/consts/SupportedNetworks.json
+++ b/src/consts/SupportedNetworks.json
@@ -3,12 +3,14 @@
     "name": "LUKSO Mainnet",
     "chainId": "42",
     "rpcUrl": "https://rpc.lukso.gateway.fm",
-    "ipfsGateway": "https://api.universalprofile.cloud/ipfs"
+    "ipfsGateway": "https://api.universalprofile.cloud/ipfs",
+    "token": "LYX"
   },
   {
     "name": "LUKSO Testnet",
     "chainId": "4201",
     "rpcUrl": "https://rpc.testnet.lukso.gateway.fm",
-    "ipfsGateway": "https://api.universalprofile.cloud/ipfs"
+    "ipfsGateway": "https://api.universalprofile.cloud/ipfs",
+    "token": "LYXt"
   }
 ]

--- a/src/contexts/EthereumContext.tsx
+++ b/src/contexts/EthereumContext.tsx
@@ -34,9 +34,14 @@ const injected = injectedModule({
 // Web3-Onboard: Set up App description
 const onboardAppMetadata = {
   name: config.metadata.title,
-  // Valid Image URL or SVG as string
-  icon: '/lyx_token_symbol.svg',
-  logo: '/lyx_token_symbol.svg',
+  /**
+   * Valid Image URL or SVG as string
+   * Icon that shows behind the extension
+   * on the right wallet side
+   */
+  icon: '/lukso_wordmark_black.svg',
+  // Logo that shows on the left
+  logo: '/lukso_wordmark_fuchsia.svg',
   description: config.metadata.description,
   recommendedInjectedWallets: [
     {

--- a/src/contexts/EthereumContext.tsx
+++ b/src/contexts/EthereumContext.tsx
@@ -1,11 +1,84 @@
 import React, { createContext, useContext, useEffect, useState } from 'react'
 import { ethers } from 'ethers'
+import Onboard, { OnboardAPI } from '@web3-onboard/core'
+import injectedModule from '@web3-onboard/injected-wallets'
+import luksoModule from '@lukso/web3-onboard-config'
+import supportedNetworks from '../consts/SupportedNetworks.json'
+import { config } from '../app/config'
+import { ConnectModalOptions } from '@web3-onboard/core/dist/types'
 
+// Web3-Onboard: LUKSO provider initialization
+const onboardLuksoProvider = luksoModule()
+
+// Web3-Onboard: Set up injected interface
+const injected = injectedModule({
+  /**
+   * Add other wallets here that you want to
+   * inject into Web3-Onboard
+   */
+  custom: [onboardLuksoProvider],
+  sort: (wallets) => {
+    const sorted = wallets.reduce<any[]>((sorted, wallet) => {
+      if (wallet.label === 'Universal Profiles') {
+        sorted.unshift(wallet)
+      } else {
+        sorted.push(wallet)
+      }
+      return sorted
+    }, [])
+    return sorted
+  },
+  displayUnavailable: ['Universal Profiles'],
+})
+
+// Web3-Onboard: Set up App description
+const onboardAppMetadata = {
+  name: config.metadata.title,
+  // Valid Image URL or SVG as string
+  icon: '/lyx_token_symbol.svg',
+  logo: '/lyx_token_symbol.svg',
+  description: config.metadata.description,
+  recommendedInjectedWallets: [
+    {
+      name: config.extension.name,
+      url: config.extension.url,
+    },
+  ],
+}
+
+/**
+ * Web3-Onboard: Set up the supported networks with strict
+ * properties based on the supportedNetworks.json
+ */
+const onboardSupportedChains = supportedNetworks.map((network) => ({
+  id: parseInt(network.chainId, 10),
+  token: network.token,
+  label: network.name,
+  rpcUrl: network.rpcUrl,
+}))
+
+// Web3-Onboard: Set up Installation Notice
+const onboardLuksoConnection: ConnectModalOptions = {
+  iDontHaveAWalletLink: config.extension.url,
+  removeWhereIsMyWalletWarning: true,
+}
+
+// Web3-Onboard: Create Onboard Component
+const web3OnboardComponent: OnboardAPI = Onboard({
+  wallets: [injected],
+  chains: onboardSupportedChains,
+  appMetadata: onboardAppMetadata,
+  connect: onboardLuksoConnection,
+})
+
+// Regular provider setup
 interface EthereumContextType {
-  provider: any
+  provider: ethers.BrowserProvider | null
   account: string | null
   connect: () => Promise<void>
   disconnect: () => void
+  useOnboard: boolean
+  toggleOnboard: () => void // Function to toggle between Web3-Onboard and regular provider
 }
 
 const defaultValue: EthereumContextType = {
@@ -13,6 +86,8 @@ const defaultValue: EthereumContextType = {
   account: null,
   connect: async () => {},
   disconnect: async () => {},
+  useOnboard: true,
+  toggleOnboard: () => {},
 }
 
 // Set up the empty React context
@@ -41,6 +116,9 @@ export function EthereumProvider({ children }: { children: React.ReactNode }) {
   const [provider, setProvider] = useState<ethers.BrowserProvider | null>(null)
   const [account, setAccount] = useState<string | null>(null)
 
+  // Adjust this state value to disable Web3-Onboard
+  const [useOnboard, setUseOnboard] = useState(true)
+
   // Initialize the provider and listen for account/chain changes
   useEffect(() => {
     if (window.ethereum) {
@@ -60,15 +138,28 @@ export function EthereumProvider({ children }: { children: React.ReactNode }) {
 
   // Connect to the Ethereum network using the user's extension
   const connect = async () => {
-    if (!provider) {
-      console.log('Provider is not set')
-      return
+    // If Web3-Onboard is enabled
+    if (useOnboard) {
+      // Connection logic using web3-onboard
+      const wallets = await web3OnboardComponent.connectWallet()
+      if (wallets.length > 0) {
+        const onboardProvider = new ethers.BrowserProvider(wallets[0].provider)
+        setProvider(onboardProvider)
+        setAccount(wallets[0].accounts[0].address)
+      }
     }
-    try {
-      const accounts = await provider.send('eth_requestAccounts', [])
-      setAccount(accounts[0])
-    } catch (error) {
-      console.log('User denied connection request')
+    // Regular Connection
+    else {
+      if (!provider) {
+        console.log('Provider is not set')
+        return
+      }
+      try {
+        const accounts = await provider.send('eth_requestAccounts', [])
+        setAccount(accounts[0])
+      } catch (error) {
+        console.log('User denied connection request')
+      }
     }
   }
 
@@ -77,9 +168,21 @@ export function EthereumProvider({ children }: { children: React.ReactNode }) {
     setAccount(null)
   }
 
+  // Toggle function
+  const toggleOnboard = () => {
+    setUseOnboard(!useOnboard)
+  }
+
   return (
     <EthereumContext.Provider
-      value={{ provider, account, connect, disconnect }}
+      value={{
+        provider,
+        account,
+        connect,
+        disconnect,
+        useOnboard,
+        toggleOnboard,
+      }}
     >
       {children}
     </EthereumContext.Provider>

--- a/src/pages/contexts.tsx
+++ b/src/pages/contexts.tsx
@@ -17,23 +17,23 @@ export default function Contexts() {
             <div className="mb-32 lg:mb-0 lg:max-w-3xl opacity-70 text-sm">
               You can import the <code className="font-bold">useEthereum</code>{' '}
               context within any page or component in order to globally manage
-              the connected Universal Profile Extension. The{' '}
+              the connected Universal Profile Browser Extension. The{' '}
               <code className="font-bold">
                 src/contexts/EthereumContext.tsx
               </code>{' '}
-              can be used to:
+              can:
               <div className="mb-32 grid text-center lg:max-w-5xl lg:w-full lg:mb-0 lg:grid-cols-4 lg:text-left group mt-4">
                 <p className="text-sm rounded-lg border px-5 py-4 border-slate-200 bg-white mr-2 text-center">
                   Get the current browser provider
                 </p>
                 <p className="text-sm rounded-lg border px-5 py-4 border-slate-200 bg-white mr-2 text-center">
-                  Connect and disconnect the Universal Profile
+                  Connect and remove the Universal Profile
                 </p>
                 <p className="text-sm rounded-lg border px-5 py-4 border-slate-200 bg-white mr-2 text-center">
                   Act on provider or address changes
                 </p>
                 <p className="text-sm rounded-lg border px-5 py-4 border-slate-200 bg-white text-center">
-                  Select wallet extensions using Web3 Onboard
+                  Toggle Web3 Onboard functionality
                 </p>
               </div>
             </div>
@@ -43,11 +43,11 @@ export default function Contexts() {
             <div className="mb-32 lg:mb-0 lg:max-w-3xl opacity-70 text-sm">
               You can import the <code className="font-bold">useProfile</code>{' '}
               context within any page or component in order to globally manage
-              profile data from the Universal Profile Extension. The{' '}
+              profile data from the Universal Profile Browser Extension. The{' '}
               <code className="font-bold">
                 src/contexts/EthereumContext.tsx
               </code>{' '}
-              can be used to:
+              can:
               <div className="mb-32 grid text-center lg:max-w-5xl lg:w-full lg:mb-0 lg:grid-cols-3 lg:text-left group mt-4">
                 <p className="text-sm rounded-lg border px-5 py-4 border-slate-200 bg-white mr-2 text-center">
                   Retrieve and decode metadata of the Universal Profile
@@ -66,9 +66,10 @@ export default function Contexts() {
             <div className="mb-32 lg:mb-0 lg:max-w-3xl opacity-70 text-sm">
               You can import the <code className="font-bold">useNetwork</code>{' '}
               context within any page or component in order to globally manage
-              the network connection of the Universal Profile Extension. The{' '}
+              the network connection of the Universal Profile Browser Extension.
+              The{' '}
               <code className="font-bold">src/contexts/NetworkContext.tsx</code>{' '}
-              can be used to:
+              can:
               <div className="mb-32 grid text-center lg:max-w-5xl lg:w-full lg:mb-0 lg:grid-cols-4 lg:text-left group mt-4">
                 <p className="text-sm rounded-lg border px-5 py-4 border-slate-200 bg-white mr-2 text-center">
                   Get the current selected network

--- a/src/pages/contexts.tsx
+++ b/src/pages/contexts.tsx
@@ -27,13 +27,13 @@ export default function Contexts() {
                   Get the current browser provider
                 </p>
                 <p className="text-sm rounded-lg border px-5 py-4 border-slate-200 bg-white mr-2 text-center">
-                  Connect to the Universal Profile
+                  Connect and disconnect the Universal Profile
                 </p>
                 <p className="text-sm rounded-lg border px-5 py-4 border-slate-200 bg-white mr-2 text-center">
                   Act on provider or address changes
                 </p>
                 <p className="text-sm rounded-lg border px-5 py-4 border-slate-200 bg-white text-center">
-                  Disconnect the Universal Profile
+                  Select wallet extensions using Web3 Onboard
                 </p>
               </div>
             </div>


### PR DESCRIPTION
This PR adds optional Web3-Onboard component for managing the Ethereum provider.

Waiting on: 

- [x] https://github.com/lukso-network/web3-onboard-config/pull/8 (Release 1.1.0)
- [x] Install `@lukso/web3-onboard-config@1.0.0`